### PR TITLE
Fix package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "GSuite",
+  "name": "vendasta/g-suite",
   "description": "PHP library for Vendasta's GSuite service",
   "type": "library",
   "require": {


### PR DESCRIPTION
[GLO-1537](https://vendasta.jira.com/browse/GLO-1537)

The default name provided by the SDK generation didn't include a vendor name and was rejected by Packagist. 

@vendasta/lucky-charms 