### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ composer require vendasta/gsuite
 
 ## Authentication
 
-To authenticate your SDK calls, you must provision a service account from within the Vendasta platform.
+To authenticate your SDK calls, you must provision a service account from within the Vendasta platform. Refer to the [service account guide](https://developers.vendasta.com/guides/service-accounts) in order to setup authentication.
 
 You must put this file on your server, and set an environment variable to its path:
 
@@ -54,17 +54,19 @@ $client = new Vendasta\GSuite\V1\PartnerServiceClient($environment);
 
 Notice that the environment will be set to DEMO if it is not specified.
 
-## Getting domain information
+## How to use this SDKS
+
+### Getting domain information
+To get the information for a domain including the TXT record and status:
 ```php
 $req = new GSuite\V1\GetDomainInformationRequest();
 $req->setDomain("<domain>");
 $resp = $client->GetDomainInformation($req);
 ```
 
-## Reducing seats
+### Reducing seats
 
-If needed, a list of subscriptions and their SKU IDs can be found [here](https://developers.google.com/admin-sdk/licensing/v1/how-tos/products). 
-
+To reduce seats on a subscription list subscriptions on a domain and then calling the ChangeSeats endpoint with a subscription ID. This [page](https://developers.google.com/admin-sdk/licensing/v1/how-tos/products) can be referenced to determine which SKU ID you would like to change seats for if there is more than one subscription on the domain.
 ```php
 $req = new ListSubscriptionsRequest();
 $req->setDomain("<domain>");
@@ -82,8 +84,8 @@ $req->setSeats(1);
 $resp = $client->ChangeSeats($req);
 ```
 
-## Disabling SSO
-
+### Disabling SSO
+SSO is turned on by default. To toggle it off:
 ```php
 $req = new UpdateSSORequest();
 $req->setDomain("<domain>");


### PR DESCRIPTION
The implementation of the SDK documentation in developer center just links to READMEs which will save us some time. I am updating this to include a few more details from the Google Doc, but let me know if I should be expanding further on any topic. One outstanding issue I have is where to put the provisioning guide. There is already an Account SDK page but it is the java SDK. Would it  make the most sense to simply add the provisioning details to the G Suite & GoDaddy READMEs respectively? 

@vendasta/lucky-charms 